### PR TITLE
adjusted memory requests to fit consumtion in development and production clusters

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -11,10 +11,10 @@ entityOperator:
     resources:
       limits:
         cpu: 400m
-        memory: 256Mi
+        memory: 288Mi
       requests:
         cpu: 20m
-        memory: 224Mi
+        memory: 256Mi
   userOperator:
     resources:
       limits:
@@ -35,10 +35,10 @@ kafka:
     resources:
       limits:
         cpu: 2000m
-        memory: 1024Mi
+        memory: 1152Mi
       requests:
         cpu: 200m
-        memory: 768Mi
+        memory: 896Mi
     storage:
       volumes:
       - class: &nfs1 nfs1
@@ -79,6 +79,6 @@ schemaRegistry:
       cpu: 400m
       memory: 512Mi
     requests:
-      cpu: 10m
-      memory: 256Mi
+      cpu: 40m
+      memory: 320Mi
   topic: kafka.private.schemas


### PR DESCRIPTION
This pull request includes updates to resource limits and requests for various components in the `values.yaml` file. The changes primarily adjust the memory and CPU allocations to better suit the needs of the application.

Resource allocation updates:

* `values.yaml` (entityOperator): Increased memory limits from `256Mi` to `288Mi` and memory requests from `224Mi` to `256Mi`.
* `values.yaml` (kafka): Increased memory limits from `1024Mi` to `1152Mi` and memory requests from `768Mi` to `896Mi`.
* `values.yaml` (schemaRegistry): Increased CPU requests from `10m` to `40m` and memory requests from `256Mi` to `320Mi`.