### PR TITLE
Upgrade Kafka to 4.0.0.

### DIFF
--- a/tests/kafka-broker_test.yaml
+++ b/tests/kafka-broker_test.yaml
@@ -12,7 +12,7 @@ tests:
   asserts:
   - matchRegex:
       path: spec.resources.limits.cpu
-      # on local cluster we expect 0 or 0m cpu limits but stimzi doesn't support it
+      # on local cluster we expect 0 or 0m cpu limits but Strimzi doesn't support it
       pattern: "^[1-9].*"
   - matchRegex:
       path: spec.resources.limits.memory
@@ -20,11 +20,11 @@ tests:
       pattern: "^[1-9].*"
   - matchRegex:
       path: spec.resources.requests.cpu
-      # on local cluster we expect 0 or 0m cpu requests but stimzi doesn't support it
+      # on local cluster we expect 0 or 0m cpu requests but Strimzi doesn't support it
       pattern: "^[1-9].*"
   - matchRegex:
       path: spec.resources.requests.memory
-      # on local cluster we expect 0 or 0Mi 0Gi memory requests but stimzi doesn't support it
+      # on local cluster we expect 0 or 0Mi 0Gi memory requests but Strimzi doesn't support it
       pattern: "^[1-9].*"
   - matchSnapshot: {}
 

--- a/tests/kafka-controller_test.yaml
+++ b/tests/kafka-controller_test.yaml
@@ -12,7 +12,7 @@ tests:
   asserts:
   - matchRegex:
       path: spec.resources.limits.cpu
-      # on local cluster we expect 0 or 0m cpu limits but stimzi doesn't support it
+      # on local cluster we expect 0 or 0m cpu limits but Strimzi doesn't support it
       pattern: "^[1-9].*"
   - matchRegex:
       path: spec.resources.limits.memory
@@ -20,11 +20,11 @@ tests:
       pattern: "^[1-9].*"
   - matchRegex:
       path: spec.resources.requests.cpu
-      # on local cluster we expect 0 or 0m cpu requests but stimzi doesn't support it
+      # on local cluster we expect 0 or 0m cpu requests but Strimzi doesn't support it
       pattern: "^[1-9].*"
   - matchRegex:
       path: spec.resources.requests.memory
-      # on local cluster we expect 0 or 0Mi 0Gi memory requests but stimzi doesn't support it
+      # on local cluster we expect 0 or 0Mi 0Gi memory requests but Strimzi doesn't support it
       pattern: "^[1-9].*"
   - matchSnapshot: {}
 

--- a/values.yaml
+++ b/values.yaml
@@ -47,7 +47,7 @@ kafka:
         type: &persistentClaim persistent-claim
     transactionStateLogMinInServiceReplicas: 2
     transactionStateLogReplicationFactor: 3
-    version: "3.9.0"
+    version: "4.0.0"
   controller:
     replicas: 5
     resources:


### PR DESCRIPTION
This change goes together with the change in strimzi-deployment.
Together they upgrade Strimzi from 0.46.0 to 0.46.1 and Kafka from 3.9.0 to 4.0.0

To test locally:

- Turn off autosync in application-root
- In application-root, enable strimzi, kafka-deployment and kafka-demo and sync.
- After all have started, switch strimzi and kafka-deployment to the PR branches and sync. Strimzi and the kafka broker, controller and entity-operator should start up successfully.

